### PR TITLE
Changed namespace for gflags functions to match project

### DIFF
--- a/cxx/CxxReplace.cpp
+++ b/cxx/CxxReplace.cpp
@@ -32,7 +32,7 @@ struct CompareTokens : std::binary_function<Token, Token, bool> {
  * the command line.
  */
 int main(int argc, char ** argv) {
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   google::InitGoogleLogging(argv[0]);
 
   if (argc <= 3) {

--- a/cxx/Main.cpp
+++ b/cxx/Main.cpp
@@ -101,7 +101,7 @@ uint checkEntry(fs::path path) {
  * command line.
  */
 int main(int argc, char ** argv) {
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   google::InitGoogleLogging(argv[0]);
 
   // Check each file


### PR DESCRIPTION
As of [March 20th](https://code.google.com/p/gflags/?redir=1#20_March_2014), the default namespace of gflags (unless compiled with special options) is gflags, not google, which breaks the compilation of flint.

Alternatively, this project could follow the folly project and use the configure script and a #Define to use the correct namespace.  I could try to write a patch for that, if it is preferred.
