### PR TITLE
Adjusted build to use the lfolly instead of hard-coded /usr/local/lib path

### DIFF
--- a/cxx/Makefile.am
+++ b/cxx/Makefile.am
@@ -13,7 +13,7 @@ libflint_la_SOURCES = \
 	Tokenizer.h \
 	Tokenizer.cpp
 libflint_la_LIBADD = \
-	/usr/local/lib/libfolly.la \
+	-lfolly \
 	$(BOOST_LIBS) \
 	$(BOOST_FILESYSTEM_LIB)
 libflint_la_CPPFLAGS = $(BOOST_CPPFLAGS)


### PR DESCRIPTION
The build breaks if you install libfolly into the standard /usr prefix instead of /usr/local, so this fixes that issue.  I also changed the build to not use .la files, since many distros strip them out, and the dynamic library path should be sufficient to find libfolly.